### PR TITLE
Fiskräknare och ny endpoint

### DIFF
--- a/backend/api/endpoints/fish.py
+++ b/backend/api/endpoints/fish.py
@@ -15,11 +15,15 @@ def get_all_fish(request) -> QuerySet[Fish]:
     fish_list = Fish.objects.all().order_by('-timestamp')
     return fish_list
 
+@router.get("/paginated", response=List[FishOut])
+def get_paginated_fish(request, offset: int = 0, limit: int = 30):
+    fish_list = Fish.objects.all().order_by('-timestamp')[offset:offset + limit]
+    return list(fish_list)
+
 @router.get("/count", response=Dict[str, int])
 def get_fish_counts(request):
     fish_counts = Fish.objects.values('species__name').annotate(count=Count('species__name'))
     counts = {fish['species__name']: fish['count'] for fish in fish_counts}
-
     return counts
 
 @router.get("/{slug}", response=FishOut)

--- a/backend/api/endpoints/fish.py
+++ b/backend/api/endpoints/fish.py
@@ -1,9 +1,9 @@
 from ninja import Router
 from django.shortcuts import get_object_or_404
-from django.db.models import QuerySet
+from django.db.models import QuerySet, Count
 from ninja.security import django_auth
 from django.views.decorators.csrf import csrf_protect
-from typing import List
+from typing import List, Dict
 from api.models import Fish, FishSpecies, Bait
 from api.schemas import FishCreate, FishOut, FishUpdate
 from core.tasks import delete_fish_images_from_s3
@@ -14,6 +14,13 @@ router = Router()
 def get_all_fish(request) -> QuerySet[Fish]:
     fish_list = Fish.objects.all().order_by('-timestamp')
     return fish_list
+
+@router.get("/count", response=Dict[str, int])
+def get_fish_counts(request):
+    fish_counts = Fish.objects.values('species__name').annotate(count=Count('species__name'))
+    counts = {fish['species__name']: fish['count'] for fish in fish_counts}
+
+    return counts
 
 @router.get("/{slug}", response=FishOut)
 def get_fish(request, slug: str):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fiskejournal",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fiskejournal",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.2",
         "axios": "^1.7.2",
@@ -14,6 +14,7 @@
         "leaflet.markercluster": "^1.5.3",
         "moment": "^2.30.1",
         "vue": "^3.4.21",
+        "vue-countup-v3": "^1.4.2",
         "vue-router": "^4.3.3",
         "vue-toastification": "^2.0.0-rc.5",
         "vuex": "^4.0.2"
@@ -1252,6 +1253,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/countup.js": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.8.0.tgz",
+      "integrity": "sha512-f7xEhX0awl4NOElHulrl4XRfKoNH3rB+qfNSZZyjSZhaAoUk6elvhH+MNxMmlmuUJ2/QNTWPSA7U4mNtIAKljQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2755,6 +2762,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-countup-v3": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/vue-countup-v3/-/vue-countup-v3-1.4.2.tgz",
+      "integrity": "sha512-nRC65jBcdgwybxqztgd/WaK8ZN5T9ECPyiCFGYFMewCsvqdRVo1CtpT7JREcPNF837Fgu/izTSFiuzrIGD6w0A==",
+      "license": "MIT",
+      "dependencies": {
+        "countup.js": "^2.6.2"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "leaflet.markercluster": "^1.5.3",
     "moment": "^2.30.1",
     "vue": "^3.4.21",
+    "vue-countup-v3": "^1.4.2",
     "vue-router": "^4.3.3",
     "vue-toastification": "^2.0.0-rc.5",
     "vuex": "^4.0.2"

--- a/frontend/src/components/StatsWidget.vue
+++ b/frontend/src/components/StatsWidget.vue
@@ -88,7 +88,7 @@
               <img src="@/assets/gös.png" alt="Gös" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ zanderCount }}</div>
+              <div class="text-3xl font-extrabold">{{ fishCounts['Gös'] }}</div>
             </div>
           </div>
           <!-- Gäddor -->
@@ -97,7 +97,7 @@
               <img src="@/assets/gädda.png" alt="Gädda" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ pikeCount }}</div>
+              <div class="text-3xl font-extrabold">{{ fishCounts['Gädda'] }}</div>
             </div>
           </div>
           <!-- Abborrar -->
@@ -106,7 +106,7 @@
               <img src="@/assets/abborre.png" alt="Abborre" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ perchCount }}</div>
+              <div class="text-3xl font-extrabold">{{ fishCounts['Abborre'] }}</div>
             </div>
           </div>
         </div>
@@ -124,9 +124,11 @@ export default {
   name: "StatsWidget",
   setup() {
     const weatherData = ref(null);
-    const pikeCount = ref(0);
-    const perchCount = ref(0);
-    const zanderCount = ref(0);
+    const fishCounts = ref({
+      'Gädaa': 0,
+      'Abborre': 0,
+      'Gös': 0
+    });
     const loading = ref(true);
     const toast = useToast();
 
@@ -143,15 +145,11 @@ export default {
       }
     };
 
-    const fetchFishData = async () => {
+    const fetchFishCounts = async () => {
       loading.value = true;
       try {
-        const response = await apiClient.get('/fish/all');
-        const fishes = response.data;
-
-        pikeCount.value = fishes.filter(fish => fish.species.name === 'Gädda').length;
-        perchCount.value = fishes.filter(fish => fish.species.name === 'Abborre').length;
-        zanderCount.value = fishes.filter(fish => fish.species.name === 'Gös').length;
+        const response = await apiClient.get('/fish/count');
+        fishCounts.value = response.data;
       } catch (error) {
         console.error('Fel vid hämtning av fiskdata:', error);
       } finally {
@@ -170,14 +168,12 @@ export default {
 
     onMounted(() => {
       fetchWeatherData();
-      fetchFishData();
+      fetchFishCounts();
     });
 
     return {
       weatherData,
-      pikeCount,
-      perchCount,
-      zanderCount,
+      fishCounts,
       loading,
       formattedDateDisplay,
       formattedDate

--- a/frontend/src/components/StatsWidget.vue
+++ b/frontend/src/components/StatsWidget.vue
@@ -88,7 +88,7 @@
               <img src="@/assets/gös.png" alt="Gös" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ fishCounts['Gös'] }}</div>
+              <count-up v-if="Number.isFinite(fishCounts['Gös'])" :endVal="fishCounts['Gös']" :duration="2" class="text-3xl font-extrabold" />
             </div>
           </div>
           <!-- Gäddor -->
@@ -97,7 +97,7 @@
               <img src="@/assets/gädda.png" alt="Gädda" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ fishCounts['Gädda'] }}</div>
+              <count-up v-if="Number.isFinite(fishCounts['Gädda'])" :endVal="fishCounts['Gädda']" :duration="2" class="text-3xl font-extrabold" />
             </div>
           </div>
           <!-- Abborrar -->
@@ -106,7 +106,7 @@
               <img src="@/assets/abborre.png" alt="Abborre" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ fishCounts['Abborre'] }}</div>
+              <count-up v-if="Number.isFinite(fishCounts['Abborre'])" :endVal="fishCounts['Abborre']" :duration="2" class="text-3xl font-extrabold" />
             </div>
           </div>
         </div>
@@ -117,11 +117,15 @@
 
 <script>
 import { ref, onMounted } from 'vue';
+import CountUp from 'vue-countup-v3';
 import apiClient from '../api';
 import { useToast } from 'vue-toastification';
 
 export default {
   name: "StatsWidget",
+  components: {
+    CountUp
+  },
   setup() {
     const weatherData = ref(null);
     const fishCounts = ref({


### PR DESCRIPTION
Lagt till 'infinite scroll' på FishTable som hämtar 30 fiskar åt gången vid scrollning istället för alla på en gång. Siffran vid antalet fångade fiskar räknar nu upp lite snyggt när sidan laddas. Lagt till en ny endpoint /fish/count som används för att endast räkna i fish.species.name-kolumnen istället för att hämta hela objektet och sedan räkna dem. 