### PR TITLE
CountUp och infinite scroll

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fiskejournal",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,6 +14,7 @@
         "leaflet.markercluster": "^1.5.3",
         "moment": "^2.30.1",
         "vue": "^3.4.21",
+        "vue-countup-v3": "^1.4.2",
         "vue-router": "^4.3.3",
         "vue-toastification": "^2.0.0-rc.5",
         "vuex": "^4.0.2"
@@ -1252,6 +1253,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/countup.js": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.8.0.tgz",
+      "integrity": "sha512-f7xEhX0awl4NOElHulrl4XRfKoNH3rB+qfNSZZyjSZhaAoUk6elvhH+MNxMmlmuUJ2/QNTWPSA7U4mNtIAKljQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2755,6 +2762,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-countup-v3": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/vue-countup-v3/-/vue-countup-v3-1.4.2.tgz",
+      "integrity": "sha512-nRC65jBcdgwybxqztgd/WaK8ZN5T9ECPyiCFGYFMewCsvqdRVo1CtpT7JREcPNF837Fgu/izTSFiuzrIGD6w0A==",
+      "license": "MIT",
+      "dependencies": {
+        "countup.js": "^2.6.2"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fiskejournal",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -16,6 +16,7 @@
     "leaflet.markercluster": "^1.5.3",
     "moment": "^2.30.1",
     "vue": "^3.4.21",
+    "vue-countup-v3": "^1.4.2",
     "vue-router": "^4.3.3",
     "vue-toastification": "^2.0.0-rc.5",
     "vuex": "^4.0.2"

--- a/frontend/public/testfile.txt
+++ b/frontend/public/testfile.txt
@@ -1,1 +1,0 @@
-Testar v1

--- a/frontend/src/components/StatsWidget.vue
+++ b/frontend/src/components/StatsWidget.vue
@@ -88,7 +88,7 @@
               <img src="@/assets/gös.png" alt="Gös" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ zanderCount }}</div>
+              <count-up v-if="Number.isFinite(fishCounts['Gös'])" :endVal="fishCounts['Gös']" :duration="2" class="text-3xl font-extrabold" />
             </div>
           </div>
           <!-- Gäddor -->
@@ -97,7 +97,7 @@
               <img src="@/assets/gädda.png" alt="Gädda" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ pikeCount }}</div>
+              <count-up v-if="Number.isFinite(fishCounts['Gädda'])" :endVal="fishCounts['Gädda']" :duration="2" class="text-3xl font-extrabold" />
             </div>
           </div>
           <!-- Abborrar -->
@@ -106,7 +106,7 @@
               <img src="@/assets/abborre.png" alt="Abborre" class="rounded-xl w-full h-full object-contain">
             </figure>
             <div class="items-center text-center p-2">
-              <div class="text-3xl font-extrabold">{{ perchCount }}</div>
+              <count-up v-if="Number.isFinite(fishCounts['Abborre'])" :endVal="fishCounts['Abborre']" :duration="2" class="text-3xl font-extrabold" />
             </div>
           </div>
         </div>
@@ -117,16 +117,22 @@
 
 <script>
 import { ref, onMounted } from 'vue';
+import CountUp from 'vue-countup-v3';
 import apiClient from '../api';
 import { useToast } from 'vue-toastification';
 
 export default {
   name: "StatsWidget",
+  components: {
+    CountUp
+  },
   setup() {
     const weatherData = ref(null);
-    const pikeCount = ref(0);
-    const perchCount = ref(0);
-    const zanderCount = ref(0);
+    const fishCounts = ref({
+      'Gädaa': 0,
+      'Abborre': 0,
+      'Gös': 0
+    });
     const loading = ref(true);
     const toast = useToast();
 
@@ -143,15 +149,11 @@ export default {
       }
     };
 
-    const fetchFishData = async () => {
+    const fetchFishCounts = async () => {
       loading.value = true;
       try {
-        const response = await apiClient.get('/fish/all');
-        const fishes = response.data;
-
-        pikeCount.value = fishes.filter(fish => fish.species.name === 'Gädda').length;
-        perchCount.value = fishes.filter(fish => fish.species.name === 'Abborre').length;
-        zanderCount.value = fishes.filter(fish => fish.species.name === 'Gös').length;
+        const response = await apiClient.get('/fish/count');
+        fishCounts.value = response.data;
       } catch (error) {
         console.error('Fel vid hämtning av fiskdata:', error);
       } finally {
@@ -170,14 +172,12 @@ export default {
 
     onMounted(() => {
       fetchWeatherData();
-      fetchFishData();
+      fetchFishCounts();
     });
 
     return {
       weatherData,
-      pikeCount,
-      perchCount,
-      zanderCount,
+      fishCounts,
       loading,
       formattedDateDisplay,
       formattedDate

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -2,7 +2,7 @@
   <div class="p-4">
     <div class="max-w-6xl mx-auto mt-2 rounded-xl shadow-2xl p-6">
       <!-- Tabs navigation -->
-      <p>Test-text för debug v1</p>
+      <p>Version 0.2.1</p>
       <div class="tabs tabs-boxed font-bold">
         <a @click="selectedTab = 'fish'" :class="{'tab-active': selectedTab === 'fish'}" class="tab tab-bordered">Fiskar</a>
         <a @click="selectedTab = 'bait'" :class="{'tab-active': selectedTab === 'bait'}" class="tab tab-bordered">Beten</a>


### PR DESCRIPTION
Lagt till [vue-countup-v3](https://www.npmjs.com/package/vue-countup-v3) för snyggare presentation av antalet fångade fiskar i StatsWidget. Lagt till en 'infinite scroll' på FishTableView för att hämta 30 fiskar åt gången vid scrollning istället för samtliga objekt i samma anrop.